### PR TITLE
"Advanced GruntJS" is an invalid name for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Advanced GruntJS",
+  "name": "Advanced-GruntJS",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-uglify": "~0.2.5"


### PR DESCRIPTION
```
$ npm install
npm ERR! install Couldn't read dependencies
npm ERR! Error: Invalid name: "Advanced GruntJS"
```
